### PR TITLE
Update bno08x_simpletest.py - I2C Clock Frequency setting

### DIFF
--- a/examples/bno08x_simpletest.py
+++ b/examples/bno08x_simpletest.py
@@ -12,7 +12,7 @@ from adafruit_bno08x import (
 )
 from adafruit_bno08x.i2c import BNO08X_I2C
 
-i2c = busio.I2C(board.SCL, board.SDA, frequency=800000)
+i2c = busio.I2C(board.SCL, board.SDA, frequency=400000)
 bno = BNO08X_I2C(i2c)
 
 bno.enable_feature(BNO_REPORT_ACCELEROMETER)


### PR DESCRIPTION
The BNO085 only supports Fast mode I2C (400kHz).

However, this frequency setting actually worked on a RasPi 0 (clock stretching issues aside) so it must be disregarded at some point  or blinka does not pass it through correctly - may not fair so well on other devices.