### PR TITLE
Update: Flexible setting sample rate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,11 @@ Usage Example
     from adafruit_bno08x.i2c import BNO08X_I2C
     from adafruit_bno08x import BNO_REPORT_ACCELEROMETER
 
+    REPORT_INTERVAL = const(100000) # 100 Hz
+    
     i2c = busio.I2C(board.SCL, board.SDA)
     bno = BNO08X_I2C(i2c)
-    bno.enable_feature(BNO_REPORT_ACCELEROMETER)
+    bno.enable_feature(BNO_REPORT_ACCELEROMETER, REPORT_INTERVAL)
 
     while True:
         accel_x, accel_y, accel_z = bno.acceleration

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,6 @@ Usage Example
     from adafruit_bno08x import BNO_REPORT_ACCELEROMETER
 
     REPORT_INTERVAL = const(100000) # 100 Hz
-    
     i2c = busio.I2C(board.SCL, board.SDA)
     bno = BNO08X_I2C(i2c)
     bno.enable_feature(BNO_REPORT_ACCELEROMETER, REPORT_INTERVAL)

--- a/adafruit_bno08x/__init__.py
+++ b/adafruit_bno08x/__init__.py
@@ -948,7 +948,7 @@ class BNO08X:
     # TODO2: I think this should call an fn that imports all the bits for the given feature
     # so we're not carrying around  stuff for extra features
     def enable_feature(
-        self, 
+        self,
         feature_id: int,
         report_interval: int = _DEFAULT_REPORT_INTERVAL,
     ) -> None:

--- a/adafruit_bno08x/__init__.py
+++ b/adafruit_bno08x/__init__.py
@@ -933,7 +933,7 @@ class BNO08X:
     @staticmethod
     def _get_feature_enable_report(
         feature_id: int,
-        report_interval: int = _DEFAULT_REPORT_INTERVAL,
+        report_interval: int,
         sensor_specific_config: int = 0,
     ) -> bytearray:
         set_feature_report = bytearray(17)
@@ -947,16 +947,20 @@ class BNO08X:
     # TODO: add docs for available features
     # TODO2: I think this should call an fn that imports all the bits for the given feature
     # so we're not carrying around  stuff for extra features
-    def enable_feature(self, feature_id: int) -> None:
+    def enable_feature(
+        self, 
+        feature_id: int,
+        report_interval: int = _DEFAULT_REPORT_INTERVAL,
+    ) -> None:
         """Used to enable a given feature of the BNO08x"""
         self._dbg("\n********** Enabling feature id:", feature_id, "**********")
 
         if feature_id == BNO_REPORT_ACTIVITY_CLASSIFIER:
             set_feature_report = self._get_feature_enable_report(
-                feature_id, sensor_specific_config=_ENABLED_ACTIVITIES
+                feature_id, report_interval, _ENABLED_ACTIVITIES
             )
         else:
-            set_feature_report = self._get_feature_enable_report(feature_id)
+            set_feature_report = self._get_feature_enable_report(feature_id, report_interval)
 
         feature_dependency = _RAW_REPORTS.get(feature_id, None)
         # if the feature was enabled it will have a key in the readings dict


### PR DESCRIPTION
# This module does not have a way to set sample rate manually. 

## _DEFAULT_REPORT_INTERVAL sets fixed rate

[_DEFAULT_REPORT_INTERVAL](https://github.com/adafruit/Adafruit_CircuitPython_BNO08x/blob/main/adafruit_bno08x/__init__.py#L118) has fixed sample rate value. 

## Need to make  _get_feature_enable_report public not private

[ _get_feature_enable_report](https://github.com/adafruit/Adafruit_CircuitPython_BNO08x/blob/main/adafruit_bno08x/__init__.py#L934) set sample rate. I needs to be get_feature_enable_report, so users can set sample rate manually. 


```bno.enable_feature(BNO_REPORT_ACCELEROMETER, REPORT_INTERVAL)```
This is how to set report interval. 
